### PR TITLE
feat: Login페이지 마크업

### DIFF
--- a/src/pages/login/Login.styled.ts
+++ b/src/pages/login/Login.styled.ts
@@ -1,0 +1,45 @@
+import { flexCenter } from "@/styles/commonStyles";
+import { getColor, getFontSize, getFontWeight } from "@/styles/theme";
+import styled from "styled-components";
+
+export const LoginContainer = styled.div`
+	width: 600px;
+	height: 550px;
+	box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+	border: 1px solid ${getColor("secondaryLight")};
+	${flexCenter}
+
+	h1 {
+		padding-bottom: 30px;
+	}
+`;
+export const LoginBox = styled.div`
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+`;
+export const LoginHeader = styled.h1`
+	font-size: ${getFontSize("xl")};
+	font-weight: ${getFontWeight("bold")};
+	display: inline;
+`;
+export const LoginForm = styled.div`
+	margin: 0 -10px;
+	${flexCenter}
+	flex-direction: column;
+	div {
+		width: 420px;
+	}
+	button {
+		margin: 10px;
+	}
+`;
+export const HelperText = styled.div`
+	padding: 0 10px;
+	color: ${getColor("danger")};
+	display: ${(props) => (props.isError ? "block" : "none")};
+`;
+export const SignUpGuide = styled.div`
+	margin-top: 30px;
+`;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,11 +1,31 @@
 import React from "react";
+import {
+	HelperText,
+	LoginBox,
+	LoginContainer,
+	LoginForm,
+	LoginHeader,
+	SignUpGuide,
+} from "./Login.styled";
+import { Button, Input } from "@/components/common";
 
 const LoginPage = () => {
 	return (
-		<>
-			Login
-			<div>Login Form</div>
-		</>
+		<LoginContainer>
+			<LoginBox>
+				<LoginHeader>로그인</LoginHeader>
+				<LoginForm>
+					<Input label={"Email"}></Input>
+					<HelperText>유효하지 않은 이메일입니다.</HelperText>
+					<Input label={"Password"} type="password"></Input>
+					<HelperText>유효하지 않은 비밀번호입니다.</HelperText>
+					<Button>로그인 하기</Button>
+				</LoginForm>
+				<SignUpGuide>
+					계정이 없으신가요? <a href="/signup">회원가입 하기</a>
+				</SignUpGuide>
+			</LoginBox>
+		</LoginContainer>
 	);
 };
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #19 

## 📝 요약

> Login 페이지 마크업
figma에는 border가 따로 없는데 색이 비슷해서 secondaryLight 컬러로 추가했습니다.
border-radius 설정이 로그인과 회원가입 페이지만 없는데 설정 원하시면 추후 설정 하겠습니다.
경고 메시지는 유효하지 않은 이메일, 비밀번호 입력 시 출력될 예정입니다.

## 💬 리뷰어에게 공유사항 (선택)

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1c412597-095b-4de4-989e-27eb5be981bd)
