### PR TITLE
feat: ActualPayment계산값 사용, select 외부클릭으로 닫기추가 

### DIFF
--- a/src/pages/salary/components/CustomDatePicker.tsx
+++ b/src/pages/salary/components/CustomDatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
 	Button,
 	Dropdown,
@@ -18,6 +18,7 @@ const CustomDatePicker = ({
 }: CustomDatePickerProps) => {
 	const today = new Date();
 	const [isPickerOpen, setIsPickerOpen] = useState(false);
+	const dropdownRef = useRef<HTMLDivElement | null>(null);
 
 	const handleYearChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
 		const newYear = parseInt(event.target.value, 10);
@@ -29,8 +30,26 @@ const CustomDatePicker = ({
 		onDateChange(new Date(selectedDate.getFullYear(), newMonth));
 	};
 
+	const handleOutsideClick = (event: MouseEvent) => {
+		if (
+			dropdownRef.current &&
+			!dropdownRef.current.contains(event.target as Node)
+		) {
+			setIsPickerOpen(false);
+		}
+	};
+
+	useEffect(() => {
+		if (isPickerOpen) {
+			document.addEventListener("mousedown", handleOutsideClick);
+			return () => {
+				document.removeEventListener("mousedown", handleOutsideClick);
+			};
+		}
+	}, [isPickerOpen]);
+
 	return (
-		<Wrapper>
+		<Wrapper ref={dropdownRef}>
 			<Button onClick={() => setIsPickerOpen(!isPickerOpen)}>
 				{`${selectedDate.getFullYear()}년 ${selectedDate.getMonth() + 1}월`}
 			</Button>

--- a/src/pages/salary/components/Graph.tsx
+++ b/src/pages/salary/components/Graph.tsx
@@ -1,4 +1,5 @@
 import type { GraphProps } from "../types/salaryPage";
+import type { SalaryData } from "../types/salaryData";
 import {
 	GraphContainer,
 	GraphDeduction,
@@ -7,7 +8,29 @@ import {
 	GraphWrapper,
 } from "./Graph.styled";
 
-const Graph = ({ salaryPercent, deductionPercent }: GraphProps) => {
+const Graph = ({ salaryData }: GraphProps) => {
+	const calculatePercentages = (data: SalaryData) => {
+		const totalDeductions =
+			data.nationalPension +
+			data.healthInsurance +
+			data.longTermCareInsurance +
+			data.employmentInsurance +
+			data.incomeTax +
+			data.localIncomeTax;
+
+		const actualPayment = data.baseSalary - totalDeductions;
+		const total = data.baseSalary;
+
+		const salaryPercent = ((actualPayment / total) * 100).toFixed(1);
+		const deductionPercent = ((totalDeductions / total) * 100).toFixed(1);
+
+		return {
+			salaryPercent: parseFloat(salaryPercent),
+			deductionPercent: parseFloat(deductionPercent),
+		};
+	};
+
+	const { salaryPercent, deductionPercent } = calculatePercentages(salaryData);
 	return (
 		<GraphWrapper>
 			<GraphContainer>

--- a/src/pages/salary/components/MonthSalaryModal.tsx
+++ b/src/pages/salary/components/MonthSalaryModal.tsx
@@ -33,9 +33,14 @@ const MonthlySalaryModal = ({ isOpen, onClose }: any) => {
 	const fetchYearlySalaryData = async (userId: string, year: string) => {
 		try {
 			const data = await getYearlySalaryData(userId, parseInt(year));
-			setYearlySalaryData(data);
+
+			if (Array.isArray(data) && data.length > 0) {
+				setYearlySalaryData(data);
+			} else {
+				setYearlySalaryData([]);
+			}
 		} catch (error) {
-			console.error(error);
+			setYearlySalaryData([]);
 		}
 	};
 

--- a/src/pages/salary/index.tsx
+++ b/src/pages/salary/index.tsx
@@ -9,6 +9,7 @@ import Header from "./components/Header";
 import SalarySection from "./components/SalarySection";
 import SalaryDetailsSection from "./components/SalaryDetailSection";
 import type { SalaryData } from "./types/salaryData";
+import { calculateActualPayment } from "@/utils/calculateSalary";
 
 const SalaryPage = () => {
 	const today = new Date();
@@ -33,9 +34,7 @@ const SalaryPage = () => {
 			data.localIncomeTax
 		);
 	};
-	const calculateActualPayment = (data: SalaryData): number => {
-		return data.baseSalary - getTotalDeductions(data);
-	};
+	const actualPayment = salaryData ? calculateActualPayment(salaryData) : 0;
 
 	const uid = useSelector((state: RootState) => state.loginAuth.uid);
 	console.log("UID:", uid);
@@ -101,7 +100,7 @@ const SalaryPage = () => {
 			{salaryData ? (
 				<>
 					<SalarySection
-						actualPayment={calculateActualPayment(salaryData)}
+						actualPayment={actualPayment}
 						isCorrectionModalOpen={isCorrectionModalOpen}
 						setIsCorrectionModalOpen={setIsCorrectionModalOpen}
 						formatNumber={formatNumber}

--- a/src/pages/salary/index.tsx
+++ b/src/pages/salary/index.tsx
@@ -33,11 +33,10 @@ const SalaryPage = () => {
 			data.localIncomeTax
 		);
 	};
-
-	const getPercentage = (value: number, data: SalaryData): number => {
-		const total = data.actualPayment + getTotalDeductions(data);
-		return total > 0 ? Math.round((value / total) * 100) : 0;
+	const calculateActualPayment = (data: SalaryData): number => {
+		return data.baseSalary - getTotalDeductions(data);
 	};
+
 	const uid = useSelector((state: RootState) => state.loginAuth.uid);
 	console.log("UID:", uid);
 
@@ -102,20 +101,15 @@ const SalaryPage = () => {
 			{salaryData ? (
 				<>
 					<SalarySection
-						actualPayment={salaryData.actualPayment}
+						actualPayment={calculateActualPayment(salaryData)}
 						isCorrectionModalOpen={isCorrectionModalOpen}
 						setIsCorrectionModalOpen={setIsCorrectionModalOpen}
 						formatNumber={formatNumber}
 						selectedDate={selectedDate}
 					/>
 
-					<Graph
-						salaryPercent={getPercentage(salaryData.actualPayment, salaryData)}
-						deductionPercent={getPercentage(
-							getTotalDeductions(salaryData),
-							salaryData,
-						)}
-					/>
+					<Graph salaryData={salaryData} />
+
 					<SalaryDetailsSection
 						salaryData={salaryData}
 						formatNumber={formatNumber}

--- a/src/pages/salary/types/salaryData.ts
+++ b/src/pages/salary/types/salaryData.ts
@@ -1,6 +1,5 @@
 export interface SalaryData {
 	payday: string;
-	actualPayment: number;
 	baseSalary: number;
 	nationalPension: number;
 	healthInsurance: number;

--- a/src/pages/salary/types/salaryPage.ts
+++ b/src/pages/salary/types/salaryPage.ts
@@ -1,8 +1,7 @@
 import { SalaryData } from "./salaryData";
 
 export interface GraphProps {
-	salaryPercent: number;
-	deductionPercent: number;
+	salaryData: SalaryData;
 }
 export interface HeaderProps {
 	selectedDate: Date;
@@ -23,4 +22,3 @@ export interface SalarySectionProps {
 	formatNumber: (value: number) => string;
 	selectedDate: any;
 }
-

--- a/src/services/SalaryService.ts
+++ b/src/services/SalaryService.ts
@@ -1,4 +1,5 @@
 import { db } from "@/firebase";
+import { calculateActualPayment } from "@/utils/calculateSalary";
 import {
 	doc,
 	setDoc,
@@ -38,16 +39,27 @@ export const getYearlySalaryData = async (userId: string, year: number) => {
 		const snapshot = await getDocs(q);
 
 		if (snapshot.empty) {
-			console.warn(` ${year}년의 정보를 찾을 수 없습니다.`);
 			return [];
 		}
 
 		return snapshot.docs.map((doc) => {
 			const data = doc.data();
+
 			const month = new Date(data.payday).getMonth() + 1;
+
+			const actualPayment = calculateActualPayment({
+				baseSalary: data.baseSalary || 0,
+				nationalPension: data.nationalPension || 0,
+				healthInsurance: data.healthInsurance || 0,
+				longTermCareInsurance: data.longTermCareInsurance || 0,
+				employmentInsurance: data.employmentInsurance || 0,
+				incomeTax: data.incomeTax || 0,
+				localIncomeTax: data.localIncomeTax || 0,
+			});
+
 			return {
 				month: `${month}월`,
-				salary: data.actualPayment,
+				salary: actualPayment,
 			};
 		});
 	} catch (error) {

--- a/src/utils/calculateSalary.ts
+++ b/src/utils/calculateSalary.ts
@@ -1,0 +1,39 @@
+import { SalaryData } from "@/pages/salary/types/salaryData";
+
+//총 공제액
+export const calculateTotalDeductions = (data: SalaryData): number => {
+	return (
+		data.nationalPension +
+		data.healthInsurance +
+		data.longTermCareInsurance +
+		data.employmentInsurance +
+		data.incomeTax +
+		data.localIncomeTax
+	);
+};
+
+//실 지급액
+export const calculateActualPayment = (data: {
+	baseSalary: number;
+	nationalPension: number;
+	healthInsurance: number;
+	longTermCareInsurance: number;
+	employmentInsurance: number;
+	incomeTax: number;
+	localIncomeTax: number;
+}): number => {
+	const totalDeductions =
+		data.nationalPension +
+		data.healthInsurance +
+		data.longTermCareInsurance +
+		data.employmentInsurance +
+		data.incomeTax +
+		data.localIncomeTax;
+
+	return data.baseSalary - totalDeductions;
+};
+
+// 총 지급액
+export const calculateGrossPayment = (data: SalaryData): number => {
+	return data.baseSalary;
+};


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #이슈번호

## 📝 요약

> ActualPayment ( 실지급액) 파이어베이스 값 삭제하고, 총지급액- 총공제액으로 계산하여 사용하도록 수정했습니다. 
>  급여조회페이지에서 년도 select박스 외부클릭으로 닫을 수 있게 추가했습니다. 

## 💬 리뷰어에게 공유사항 (선택)

## 📸 스크린샷 (선택)
