### PR TITLE
fix: 닫기버튼 수정, 헤더 변경 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,7 +34,7 @@ const Header = () => {
 
 				<Nav>
 					<NavLink to="/">내 일정</NavLink>
-					<NavLink to="/salary">급여내역 조회</NavLink>
+					<NavLink to="/salary">급여 내역 조회</NavLink>
 					<NavLink to="/salary-correction">정정 신청 내역</NavLink>
 					<NavLink to="/mypage">마이페이지</NavLink>
 				</Nav>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -35,7 +35,7 @@ const Header = () => {
 				<Nav>
 					<NavLink to="/">내 일정</NavLink>
 					<NavLink to="/salary">급여내역 조회</NavLink>
-					<NavLink to="/salary-correction">급여 정정 신청</NavLink>
+					<NavLink to="/salary-correction">정정 신청 내역</NavLink>
 					<NavLink to="/mypage">마이페이지</NavLink>
 				</Nav>
 			</LeftContainer>
@@ -52,10 +52,7 @@ const Header = () => {
 				</ProfileInfo>
 
 				<ProfileImageContainer>
-					<Profile
-						src={user ? user.photoURL : profileImage}
-						alt="프로필 이미지"
-					/>
+					<Profile src={user?.photoURL || profileImage} alt="프로필 이미지" />
 				</ProfileImageContainer>
 			</ProfileContainer>
 		</HeaderContainer>

--- a/src/components/Modal/Modal.styled.ts
+++ b/src/components/Modal/Modal.styled.ts
@@ -41,7 +41,7 @@ export const ModalHeader = styled.header`
 	position: relative;
 
 	h2 {
-		margin: 0;
+		margin: 5px 0;
 		font-size: ${getFontSize("xl")};
 		font-weight: ${getFontWeight("bold")};
 		text-align: center;

--- a/src/components/Modal/Modal.styled.ts
+++ b/src/components/Modal/Modal.styled.ts
@@ -60,4 +60,5 @@ export const ButtonContainer = styled.div`
 	justify-content: center;
 	gap: 20px;
 	margin-top: 20px;
+	margin: 0 10px;
 `;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -16,8 +16,7 @@ const Modal = ({
 	title,
 	onClose,
 	children,
-	confirmLabel = "확인",
-	onConfirm,
+	buttons = [],
 }: ModalProps) => {
 	useEffect(() => {
 		const preventGoBack = () => {
@@ -42,12 +41,16 @@ const Modal = ({
 					</ModalHeader>
 					<ModalContent>{children}</ModalContent>
 					<ButtonContainer>
-						<Button buttonType={"white"} size={"small"} onClick={onClose}>
-							취소
-						</Button>
-						<Button size={"small"} onClick={onConfirm || onClose}>
-							{confirmLabel}
-						</Button>
+						{buttons.map(({ label, size, onClick, buttonType }, idx) => (
+							<Button
+								key={idx}
+								buttonType={buttonType} 
+								size={size} 
+								onClick={onClick}
+							>
+								{label}
+							</Button>
+						))}
 					</ButtonContainer>
 				</ModalBox>
 			</ModalContainer>

--- a/src/components/TextArea/TextArea.styled.ts
+++ b/src/components/TextArea/TextArea.styled.ts
@@ -36,7 +36,7 @@ export const TextAreaBox = styled.textarea<{ $isError?: boolean }>`
 	outline: none;
 	${({ readOnly }) => getReadOnlyStyles(readOnly)};
 	resize: vertical;
-	min-height: 150px;
+	min-height: 180px;
 
 	&:focus {
 		${({ readOnly }) =>

--- a/src/pages/salary-correction/components/HistoryModal.tsx
+++ b/src/pages/salary-correction/components/HistoryModal.tsx
@@ -11,17 +11,18 @@ const HistoryModal = ({
 	reason,
 	history,
 }: any) => {
-	const handleApply = () => {
-		onClose();
-	};
-
 	return (
 		<Modal
 			isOpen={isOpen}
 			title="정정 신청 내역"
 			onClose={onClose}
-			confirmLabel="확인"
-			onConfirm={handleApply}
+			buttons={[
+				{
+					label: "닫기",
+					onClick: onClose,
+					buttonType: "white",
+				},
+			]}
 		>
 			<Container>
 				<Label>정정 내역</Label>
@@ -34,7 +35,6 @@ const HistoryModal = ({
 					<StatusBadge status={status} />
 				</Row>
 			</Container>
-
 			<Input
 				label="정정 사항 선택 *"
 				value={correctionType}

--- a/src/pages/salary/components/CorrectionModal.tsx
+++ b/src/pages/salary/components/CorrectionModal.tsx
@@ -86,8 +86,20 @@ const CorrectionModal = ({
 			isOpen={isOpen}
 			title="정정신청"
 			onClose={onClose}
-			confirmLabel="신청"
-			onConfirm={handleApply}
+			buttons={[
+				{
+					label: "취소",
+					onClick: onClose,
+					buttonType: "white",
+					size: "small",
+				},
+				{
+					label: "신청",
+					onClick: handleApply,
+					size: "small",
+					buttonType: "primary",
+				},
+			]}
 		>
 			<CustomSelect
 				label="정정 사항 선택 * "

--- a/src/pages/salary/components/MonthSalaryModal.styled.ts
+++ b/src/pages/salary/components/MonthSalaryModal.styled.ts
@@ -3,8 +3,8 @@ import styled from "styled-components";
 
 export const ListContainer = styled.ul`
 	list-style: none;
-	padding: 0;
-	margin: 0;
+	padding-left: 10px;
+	margin-left: 8px;
 	border-bottom: 1px solid ${getColor("grayLight")};
 	border-radius: ${getBorderRadius("sm")};
 	overflow: scroll;
@@ -32,7 +32,7 @@ export const ListItem = styled.li`
 export const Month = styled.div`
 	font-size: 18px;
 	font-weight: ${getFontWeight("bold")};
-	padding-left: 30px;
+	padding-left: 20px;
 	cursor: pointer;
 `;
 

--- a/src/pages/salary/components/MonthSalaryModal.tsx
+++ b/src/pages/salary/components/MonthSalaryModal.tsx
@@ -45,7 +45,18 @@ const MonthlySalaryModal = ({ isOpen, onClose }: any) => {
 	};
 
 	return (
-		<Modal isOpen={isOpen} title="월별 급여" onClose={onClose}>
+		<Modal
+			isOpen={isOpen}
+			title="월별 급여"
+			onClose={onClose}
+			buttons={[
+				{
+					label: "닫기",
+					onClick: onClose,
+					buttonType: "white",
+				},
+			]}
+		>
 			<CustomSelect
 				options={years.map((year) => ({ value: year, label: year }))}
 				value={selectedYear}

--- a/src/pages/schedule/components/Modal/ScheduleDetailModal.tsx
+++ b/src/pages/schedule/components/Modal/ScheduleDetailModal.tsx
@@ -22,8 +22,20 @@ const ScheduleDetailModal = ({
 			isOpen={isOpen}
 			title="일정 상세"
 			onClose={onClose}
-			confirmLabel="수정"
-			onConfirm={onConfirm}
+			buttons={[
+				{
+					label: "취소",
+					onClick: onClose,
+					buttonType: "white",
+					size: "small",
+				},
+				{
+					label: "수정",
+					onClick: onConfirm,
+					size: "small",
+					buttonType: "primary",
+				},
+			]}
 		>
 			<DetailInputContainer>
 				<DetailLabel>제목</DetailLabel>

--- a/src/pages/schedule/components/Modal/ScheduleFormModal.tsx
+++ b/src/pages/schedule/components/Modal/ScheduleFormModal.tsx
@@ -100,8 +100,20 @@ const ScheduleFormModal = ({
 			isOpen={isOpen}
 			title={modalTitle}
 			onClose={onClose}
-			confirmLabel={confirmLabel}
-			onConfirm={handleApply}
+			buttons={[
+				{
+					label: "취소",
+					onClick: onClose,
+					buttonType: "white",
+					size: "small",
+				},
+				{
+					label: confirmLabel,
+					onClick: handleApply,
+					buttonType: "primary",
+					size: "small",
+				},
+			]}
 		>
 			<Input
 				type="text"

--- a/src/types/components/button.ts
+++ b/src/types/components/button.ts
@@ -3,8 +3,8 @@ export type ButtonSize = "regular" | "small";
 
 export interface ButtonProps {
 	children: React.ReactNode;
-	buttonType?: ButtonType;
-	size?: ButtonSize;
+	buttonType?: ButtonType | undefined; 
+	size?: ButtonSize | undefined; 
 	onClick?: () => void;
 	disabled?: boolean;
 }

--- a/src/types/components/modal.ts
+++ b/src/types/components/modal.ts
@@ -1,3 +1,5 @@
+import { ButtonSize, ButtonType } from "./button";
+
 export interface ModalProps {
 	isOpen: boolean;
 	title: string;
@@ -5,4 +7,11 @@ export interface ModalProps {
 	children: React.ReactNode;
 	confirmLabel?: string;
 	onConfirm?: () => void;
+	buttons?: ModalButton[];
+}
+export interface ModalButton {
+	label: string;
+	onClick: () => void;
+	buttonType?: ButtonType; 
+	size?: ButtonSize;
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> close #56 

## 📝 요약

> 모달은 외부에서 동적으로 하단 버튼내용을 정할 수있도록 수정했습니다. 
> 공통컴포넌트를 수정해서 모달이 사용된 부분 전체적으로 수정했습니다.
> 

## 💬 리뷰어에게 공유사항 (선택)

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6d1eca68-2ad6-40be-81ed-a1ea40a732eb)
닫기버튼만 수정한 상태입니다.(readonly -> text 수정예정)\
![image](https://github.com/user-attachments/assets/c8ff9a8f-2ebc-4583-a7e0-7366b59c85bd)
![image](https://github.com/user-attachments/assets/4d8b8d4c-e1ef-4a19-85ab-ddd94199558c)
