### PR TITLE
fix: 이번달 버튼css, readonly 스타일 수정,월별급여 포인터

### DIFF
--- a/src/components/Input/Input.style.ts
+++ b/src/components/Input/Input.style.ts
@@ -1,16 +1,10 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import {
 	getBorderRadius,
 	getColor,
 	getFontSize,
 	getFontWeight,
 } from "@/styles/theme";
-
-const getReadOnlyStyles = (readOnly?: boolean) => css`
-	background-color: ${getColor(readOnly ? "grayLight" : "white")};
-	color: ${getColor(readOnly ? "grayDark" : "secondaryDark")};
-	cursor: ${readOnly ? "not-allowed" : "text"};
-`;
 
 export const InputContainer = styled.div`
 	padding: 10px;
@@ -34,15 +28,12 @@ export const InputBox = styled.input<{ $isError: boolean }>`
 		${({ $isError }) => getColor($isError ? "danger" : "grayLight")};
 	border-radius: ${getBorderRadius("sm")};
 	outline: none;
-	${({ readOnly }) => getReadOnlyStyles(readOnly)};
+	background-color: ${getColor("white")};
+	color: ${getColor("secondaryDark")};
+	cursor: text;
 
 	&:focus {
-		${({ readOnly }) =>
-			readOnly
-				? css`2px solid`
-				: css`
-						border: 2px solid ${getColor("primary")};
-					`}
+		border: 2px solid ${getColor("primary")};
 	}
 
 	&[type="color"] {
@@ -56,10 +47,6 @@ export const InputBox = styled.input<{ $isError: boolean }>`
 		border: none;
 
 		cursor: pointer;
-
-		&[readonly] {
-			pointer-events: none;
-		}
 
 		&::-webkit-color-swatch {
 			border-radius: 50%;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -8,7 +8,6 @@ const Input = ({
 	value,
 	onChange,
 	type,
-	readOnly,
 	name,
 }: InputProps) => {
 	return (
@@ -20,11 +19,11 @@ const Input = ({
 				onChange={onChange}
 				type={type}
 				$isError={!!error}
-				readOnly={readOnly}
 				name={name}
 			/>
 			{error && <ErrorMessage>{error}</ErrorMessage>}
 		</InputContainer>
 	);
 };
+
 export default Input;

--- a/src/components/TextArea/TextArea.styled.ts
+++ b/src/components/TextArea/TextArea.styled.ts
@@ -1,16 +1,10 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import {
 	getBorderRadius,
 	getColor,
 	getFontSize,
 	getFontWeight,
 } from "@/styles/theme";
-
-const getReadOnlyStyles = (readOnly?: boolean) => css`
-	background-color: ${getColor(readOnly ? "grayLight" : "white")};
-	color: ${getColor(readOnly ? "grayDark" : "secondaryDark")};
-	cursor: ${readOnly ? "not-allowed" : "text"};
-`;
 
 export const TextAreaContainer = styled.div`
 	padding: 10px;
@@ -34,17 +28,14 @@ export const TextAreaBox = styled.textarea<{ $isError?: boolean }>`
 		${({ $isError }) => getColor($isError ? "danger" : "grayLight")};
 	border-radius: ${getBorderRadius("sm")};
 	outline: none;
-	${({ readOnly }) => getReadOnlyStyles(readOnly)};
 	resize: vertical;
 	min-height: 150px;
+	background-color: ${getColor("white")};
+	color: ${getColor("secondaryDark")};
+	cursor: text;
 
 	&:focus {
-		${({ readOnly }) =>
-			readOnly
-				? css`2px solid`
-				: css`
-						border: 2px solid ${getColor("primary")};
-					`}
+		border: 2px solid ${getColor("primary")};
 	}
 `;
 

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -12,7 +12,6 @@ const TextArea = ({
 	placeholder,
 	value,
 	onChange,
-	readOnly,
 }: TextAreaProps) => {
 	return (
 		<TextAreaContainer>
@@ -22,7 +21,6 @@ const TextArea = ({
 				value={value}
 				onChange={onChange}
 				$isError={!!error}
-				readOnly={readOnly}
 			/>
 			{error && <ErrorMessage>{error}</ErrorMessage>}
 		</TextAreaContainer>

--- a/src/pages/salary-correction/components/HistoryModal.styled.ts
+++ b/src/pages/salary-correction/components/HistoryModal.styled.ts
@@ -39,4 +39,5 @@ export const Reason = styled.div`
 	overflow-wrap: break-word;
 	width: 100%;
 	max-width: 300px;
+	min-height: 120px;
 `;

--- a/src/pages/salary-correction/components/HistoryModal.styled.ts
+++ b/src/pages/salary-correction/components/HistoryModal.styled.ts
@@ -6,7 +6,6 @@ export const Container = styled.div`
 	flex-direction: column;
 	padding: 12px;
 	padding-bottom: 5px;
-	border-bottom: 1px solid ${getColor("grayLight")};
 `;
 
 export const Label = styled.div`
@@ -21,10 +20,23 @@ export const Row = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	margin-bottom: 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid ${getColor("grayLight")};
 `;
 
 export const Amount = styled.div`
-	font-size: 17px;
+	font-size: ${getFontSize("md")};
 	font-weight: ${getFontWeight("medium")};
 	color: ${getColor("grayDark")};
+`;
+export const Reason = styled.div`
+	font-size: ${getFontSize("md")};
+	font-weight: ${getFontWeight("medium")};
+	color: ${getColor("grayDark")};
+	text-align: left;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+	width: 100%;
+	max-width: 300px;
 `;

--- a/src/pages/salary-correction/components/HistoryModal.tsx
+++ b/src/pages/salary-correction/components/HistoryModal.tsx
@@ -1,7 +1,6 @@
 import Modal from "@/components/Modal";
-import { Input, TextArea } from "@/components";
 import StatusBadge from "./StatusBadge";
-import { Amount, Container, Label, Row } from "./HistoryModal.styled";
+import { Amount, Container, Label, Reason, Row } from "./HistoryModal.styled";
 
 const HistoryModal = ({
 	isOpen,
@@ -34,14 +33,18 @@ const HistoryModal = ({
 					<StatusBadge status={status} />
 				</Row>
 			</Container>
-
-			<Input
-				label="정정 사항 선택 *"
-				value={correctionType}
-				readOnly
-				type="text"
-			/>
-			<TextArea label="정정 사유를 입력하세요 *" value={reason} readOnly />
+			<Container>
+				<Label>정정 사항 선택</Label>
+				<Row>
+					<Amount>{correctionType}</Amount>
+				</Row>
+			</Container>
+			<Container>
+				<Label>정정 사유</Label>
+				<Row>
+					<Reason>{reason}</Reason>
+				</Row>
+			</Container>
 		</Modal>
 	);
 };

--- a/src/pages/salary-correction/components/StatusBadge.styled.ts
+++ b/src/pages/salary-correction/components/StatusBadge.styled.ts
@@ -6,8 +6,8 @@ export const Badge = styled.span<{ $status: string }>`
 	padding: 5px 10px;
 	font-size: 14px;
 	font-weight: ${getFontWeight("medium")};
-	border-radius: 20px;
-	margin-bottom: 8px;
+	border-radius: 1120px;
+	margin-bottom: 4px;
 	text-align: center;
 	width: 80px;
 	align-items: center;

--- a/src/pages/salary/components/Header.styled.ts
+++ b/src/pages/salary/components/Header.styled.ts
@@ -38,15 +38,19 @@ export const Title = styled.h1`
 
 export const MonthButton = styled.button`
 	font-family: inherit;
-	padding: 8px 16px;
+	padding: 10px 20px;
 	font-size: ${getFontSize("sm")};
+	font-weight: ${getFontWeight("medium")};
 	background-color: transparent;
 	color: black;
-	border: none;
+	border: 1px solid ${getColor("grayLight")};
+	border-radius: 4px;
 	cursor: pointer;
 
 	&:hover {
-		background-color: ${getColor("grayLight")};
+		background-color: ${getColor("grayWhite")};
+		color: ${getColor("primary")};
+		font-weight: ${getFontWeight("bold")};
 	}
 `;
 

--- a/src/pages/salary/components/Header.styled.ts
+++ b/src/pages/salary/components/Header.styled.ts
@@ -38,18 +38,16 @@ export const Title = styled.h1`
 
 export const MonthButton = styled.button`
 	font-family: inherit;
-	padding: 10px 20px;
-	font-size: ${getFontSize("sm")};
-	font-weight: ${getFontWeight("medium")};
+	padding: 5px 5px 8px 5px;
+	font-size: 18px;
+	font-weight: ${getFontWeight("bold")};
 	background-color: transparent;
 	color: black;
-	border: 1px solid ${getColor("grayLight")};
-	border-radius: 4px;
+	color: ${getColor("primary")};
 	cursor: pointer;
 
 	&:hover {
-		background-color: ${getColor("grayWhite")};
-		color: ${getColor("primary")};
+		color: ${getColor("secondaryDark")};
 		font-weight: ${getFontWeight("bold")};
 	}
 `;

--- a/src/pages/salary/components/Header.tsx
+++ b/src/pages/salary/components/Header.tsx
@@ -28,7 +28,9 @@ const Header = ({
 		</DateContainer>
 		<ButtonGroup>
 			<TopButtons>
-				<MonthButton onClick={() => setSelectedDate(today)}>이번달</MonthButton>
+				<MonthButton onClick={() => setSelectedDate(today)}>
+					이번 달
+				</MonthButton>
 				<MonthChangeButton
 					onClick={() =>
 						setSelectedDate(

--- a/src/pages/salary/components/MonthSalaryModal.styled.ts
+++ b/src/pages/salary/components/MonthSalaryModal.styled.ts
@@ -3,12 +3,12 @@ import styled from "styled-components";
 
 export const ListContainer = styled.ul`
 	list-style: none;
-	padding: 0;
-	margin: 0;
+	padding-left: 10px;
+	margin-left: 8px;
 	border-bottom: 1px solid ${getColor("grayLight")};
 	border-radius: ${getBorderRadius("sm")};
 	overflow: scroll;
-	height: 250px;
+	height: 280px;
 	width: 400px;
 	overflow-x: hidden;
 `;
@@ -32,8 +32,7 @@ export const ListItem = styled.li`
 export const Month = styled.div`
 	font-size: 18px;
 	font-weight: ${getFontWeight("bold")};
-	padding-left: 30px;
-	cursor: pointer;
+	padding-left: 20px;
 `;
 
 export const Salary = styled.div`
@@ -41,5 +40,4 @@ export const Salary = styled.div`
 	font-weight: ${getFontWeight("medium")};
 	color: ${getColor("grayDark")};
 	padding-right: 10px;
-	cursor: pointer;
 `;

--- a/src/types/components/input.ts
+++ b/src/types/components/input.ts
@@ -5,6 +5,5 @@ export interface InputProps {
 	value?: string;
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	type?: string;
-	readOnly?: boolean;
 	name?: string;
 }

--- a/src/types/components/textarea.ts
+++ b/src/types/components/textarea.ts
@@ -4,5 +4,4 @@ export interface TextAreaProps {
 	placeholder?: string;
 	value?: string;
 	onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-	readOnly?: boolean;
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> close #61 

## 📝 요약

> 이번달 버튼 좀더 강조했고, readonly 를 아예 제거하고 정정내역에서는 필드마다 동일한 text 스타일로 통일했고, 월별급여 포인터도 제거했습니다~ 

## 💬 리뷰어에게 공유사항 (선택)
이번달 을 버튼으로 또만들기에는 월별급여까지 버튼이 너무 많은 것 같아서 색깔로 강조했고, 
호버하면 색상 바뀌게 수정했습니다~
readonly 속성사용안하고 정정내역과 통일성있게 css 수정했는데, 내용이 짧을때는 좀뭔가..애매한것 같습니다..

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/dc86ef4a-b6b2-4174-beab-ce06435cc6d8)

![image](https://github.com/user-attachments/assets/78ef3021-22fe-42bc-9813-418d81e82acf)
![image](https://github.com/user-attachments/assets/164fc8df-96db-466d-a029-64926a8d79ac)
